### PR TITLE
:finger-shake: its asc718

### DIFF
--- a/misspellings_lib_hurkman/custom.json
+++ b/misspellings_lib_hurkman/custom.json
@@ -48,5 +48,6 @@
     "RequestFactory": ["ban-request-factory"],
     "uuid1": ["use-uuid4-not-uuid1"],
     "simplejson": ["use-json-instead"],
-    "lorem": ["lorem-ipsum-text"]
+    "lorem": ["lorem-ipsum-text"],
+    "ASC728": ["ASC718"],
 }

--- a/misspellings_lib_hurkman/custom.json
+++ b/misspellings_lib_hurkman/custom.json
@@ -49,5 +49,5 @@
     "uuid1": ["use-uuid4-not-uuid1"],
     "simplejson": ["use-json-instead"],
     "lorem": ["lorem-ipsum-text"],
-    "ASC728": ["ASC718"],
+    "ASC728": ["ASC718"]
 }


### PR DESCRIPTION
Maybe it's overly specific, but "ASC728" should fail tests. Really they should write "expense accounting".