### PR TITLE
Removing never-say-successfully rule since "successfully" is the prop…

### DIFF
--- a/misspellings_lib_hurkman/custom.json
+++ b/misspellings_lib_hurkman/custom.json
@@ -22,7 +22,6 @@
     "styleistic": ["stylistic"],
     "unconditionnally": ["unconditionally"],
     "please": ["never-say-please"],
-    "successfully": ["never-say-successfully"],
     "successfull": ["never-say-successful"],
     "tranfer": ["transfer"],
     "certifcate": ["certificate"],


### PR DESCRIPTION
Removing never-say-successfully rule since "successfully" is the proper adverb for successful. [Merriam-Webster/successful](https://www.merriam-webster.com/dictionary/successful)