### PR TITLE
Fix test_split_words_with_camel_case unit test

### DIFF
--- a/misspellings_lib_hurkman/__init__.py
+++ b/misspellings_lib_hurkman/__init__.py
@@ -21,8 +21,7 @@ import string
 
 __version__ = '10.4'
 
-
-_NORM_REGEX = re.compile(r'([A-Z][A-Za-z]*)')
+_NORM_REGEX = re.compile(r'([A-Z][a-z]+)')
 _WORD_REGEX = re.compile(r'[\s_0-9\W]+', flags=re.UNICODE)
 
 


### PR DESCRIPTION
```
======================================================================
FAIL: test_split_words_with_camel_case (test_class.UtilityFunctionTestCase)                                                      
----------------------------------------------------------------------                                                           
Traceback (most recent call last):                   
  File "/Users/davidleong/IdeaProjects/tianseng_misspellings/tests/test_class.py", line 92, in test_split_words_with_camel_case  
    self.assertEqual(['one', 'Two', 'Three'],          
AssertionError: Lists differ: ['one', 'Two', 'Three'] != ['one', 'TwoThree']                                                     
                                                                
First differing element 1:              
'Two'                                      
'TwoThree'                                    
                                                                
First list contains 1 additional elements.                
First extra element 2:                                    
'Three'                                                                                                                          
                                                                                                                                 
- ['one', 'Two', 'Three']                                   
?             ----                                                                                                               
                                                                                                                                 
+ ['one', 'TwoThree']                                                                                                            
                                                                                                                                 
----------------------------------------------------------------------       
Ran 24 tests in 1.202s               

```